### PR TITLE
added tck option to create.km.plot

### DIFF
--- a/R/create.km.plot.R
+++ b/R/create.km.plot.R
@@ -82,6 +82,8 @@ create.km.plot <- function(
 	right.padding = 0.1,
 	left.padding = 0.5,
 	return.statistics = FALSE,
+    xaxis.tck = 1,
+    yaxis.tck = 1,
 	height = 7, 
 	width = 7,
 	style = 'BoutrosLab', 
@@ -240,7 +242,7 @@ create.km.plot <- function(
 	if (ngroups > length(line.colours)) {
 		stop('There are not enough colours to plot each risk group in a different colour. Add more colours to the line.colours parameter or to the survival palette in default.colours.');
 		}
-  
+
 	# if the user hasn't set it, decide which statistical method to use
 	if (is.na(statistical.method) & is.null(predefined.p)) { 
 
@@ -877,6 +879,8 @@ create.km.plot <- function(
 		yat = yat,
 		xaxis.cex = xaxis.cex,
 		yaxis.cex = yaxis.cex,
+        xaxis.tck = xaxis.tck,
+        yaxis.tck = yaxis.tck,
 		type = c('s','p'),
 		cex = censoring.pch.cex, 
 		pch = c(rep('|', times = ngroups),rep('', times = ngroups)), 

--- a/man/create.km.plot.Rd
+++ b/man/create.km.plot.Rd
@@ -61,6 +61,8 @@ create.km.plot(
 	right.padding = 0.1,
 	left.padding = 0.5,
 	return.statistics = FALSE,
+    xaxis.tck = 1,
+    yaxis.tck = 1,
 	height = 7, 
 	width = 7, 
 	style = 'BoutrosLab',
@@ -130,6 +132,8 @@ create.km.plot(
   \item{right.padding}{A number specifying the distance to the right margin, defaults to 0.1}
   \item{left.padding}{A number specifying the distance to the left margin, defaults to 0.5.  This parameter (along with ylab.axis.padding) can be changed to make more space to display long group names in the risk table.}
   \item{return.statistics}{If TRUE, function will return a list containing trellis object (or 0/1 indicator) and relevant statistics.  If FALSE, no statistics are returned.  Defaults to FALSE.}
+  \item{xaxis.tck}{Length of tick marks on x-axis, defaults to 1}
+  \item{yaxis.tck}{Length of tick marks on y-axis, defaults to 1}
   \item{height}{Figure height in size.units}
   \item{width}{Figure width in size.units}
   \item{style}{defaults to \dQuote{BoutrosLab}, also accepts \dQuote{Nature}, which changes parameters according to Nature formatting requirements}


### PR DESCRIPTION
# Description

Addressing my own issue about not exposing the xaxis.tck and yaxis.tck options to the user. https://github.com/uclahs-cds/package-BoutrosLab-plotting-survival/issues/13

### Closes #13 <!-- https://github.com/uclahs-cds/package-BoutrosLab-plotting-survival/issues/13 -->

<!-- 
Admin/maintainer: please edit the 'Pipeline Run Results' or 'Analysis Results' sections as needed for your project repo.  
Then commit/push the changes so everyone uses this template for future PRs.

For example, if your project is a `pipeline`, then create a 'Pipeline Run Results' section.

If your project is a general data analysis project, then you may want to require an 'Analysis Results' section in order to test
code from each PR to help prevent creating new bugs.
-->

## Analysis Results

- Case 1
    - script: /hot/user/ragrawal/git/project-ProstateCancer-ARSM/src/km_treatment_bcr.R
    - command:  Rscript <script name>
    - output:  /hot/project/disease/ProstateTumor/PRAD-000090-ARSM-EMT/figures/survival/2024-04-04_treatment_km_ADTEMT.tiff

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [X] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [X] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [ ] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [ ] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

